### PR TITLE
refer to fixed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To migrate from ChiliProject 3.x back to Redmine 2.1 we used the guide provided 
 But we faced with several problems which can be solved with this howto and resources provided here.
 
 *Update:* There's a new Ruby script, which seems to do the same sql database migration task as the Java tool chili-to-redmine:
-https://gist.github.com/pallan/6663018
+https://gist.github.com/pille/603702cbb8422cc4244c
 
 ## Problems
 


### PR DESCRIPTION
forked from https://gist.githubusercontent.com/pallan/6663018/raw/a70f962712425d3447e4027ef0bdec029e3d8ac8/chiliproject_to_redmine.rb
- additionally tries to migrate the wiki history
- it successfully ran a migration of an chiliproject-2.11.0 -> redmine-2.1 installation with >16000 issues and >200 wiki pages using ruby-2.0.
- upgrading to redmine 3.1.2 went fine, afterwards.
